### PR TITLE
klte: match multiple variants' audio with single defconfig

### DIFF
--- a/arch/arm/kernel/setup.c
+++ b/arch/arm/kernel/setup.c
@@ -95,6 +95,14 @@ unsigned int __atags_pointer __initdata;
 unsigned int system_rev;
 EXPORT_SYMBOL(system_rev);
 
+/*
+ * 0 : kltexx
+ * 1 : klteskt, kltektt, kltelgt
+ * 2 : kltejpn
+ */
+unsigned int hardware_type = 0;
+EXPORT_SYMBOL(hardware_type);
+
 unsigned int system_serial_low;
 EXPORT_SYMBOL(system_serial_low);
 
@@ -599,6 +607,23 @@ static int __init msm_hw_rev_setup(char *p)
 			return 0;
 }
 early_param("samsung.board_rev", msm_hw_rev_setup);
+
+static char __initdata hardware_name[10];
+static int __init msm_hw_name_setup(char *p)
+{
+	strlcpy(hardware_name, p, sizeof(hardware_name));
+
+	if (!strncmp(hardware_name, "SM-G900S", 8) ||
+	    !strncmp(hardware_name, "SM-G900K", 8) ||
+	    !strncmp(hardware_name, "SM-G900L", 8)) {
+		hardware_type = 1;
+	} else if (!strncmp(hardware_name, "SM-G900J", 8)) {
+		hardware_type = 2;
+	}
+
+	return 0;
+}
+early_param("samsung.hardware", msm_hw_name_setup);
 
 static void __init
 setup_ramdisk(int doload, int prompt, int image_start, unsigned int rd_sz)

--- a/drivers/misc/sec_jack.c
+++ b/drivers/misc/sec_jack.c
@@ -945,31 +945,30 @@ static struct platform_driver sec_jack_driver = {
 	},
 };
 
-#if defined(CONFIG_MACH_KLTE_KOR) || defined(CONFIG_MACH_KLTE_JPN)
 extern unsigned int system_rev;
-#endif
+extern unsigned int hardware_type;
 
 static int __init sec_jack_init(void)
 {
-#if defined(CONFIG_MACH_KLTE_KOR)
-	if (system_rev >= 13) {
-		pr_info("%s: Do not use sec jack in system_rev %d",
-			__func__, system_rev);
-		return 0;
+	if (hardware_type == 1) {
+		if (system_rev >= 13) {
+			pr_info("%s: Do not use sec jack in system_rev %d",
+				__func__, system_rev);
+			return 0;
+		} else {
+			return platform_driver_register(&sec_jack_driver);
+		}
+	} else if (hardware_type == 2) {
+		if (system_rev >= 11) {
+			pr_info("%s: Do not use sec jack in system_rev %d",
+				__func__, system_rev);
+			return 0;
+		} else {
+			return platform_driver_register(&sec_jack_driver);
+		}
 	} else {
 		return platform_driver_register(&sec_jack_driver);
 	}
-#elif defined(CONFIG_MACH_KLTE_JPN)
-	if (system_rev >= 11) {
-		pr_info("%s: Do not use sec jack in system_rev %d",
-			__func__, system_rev);
-		return 0;
-	} else {
-		return platform_driver_register(&sec_jack_driver);
-	}
-#else
-	return platform_driver_register(&sec_jack_driver);
-#endif
 }
 
 static void __exit sec_jack_exit(void)

--- a/sound/soc/codecs/wcd9320.c
+++ b/sound/soc/codecs/wcd9320.c
@@ -1537,59 +1537,59 @@ static const struct snd_kcontrol_new taiko_2_x_analog_gain_controls[] = {
 			analog_gain),
 };
 
-#if defined(CONFIG_MACH_KLTE_JPN) || defined(CONFIG_MACH_KLTE_KOR)
 extern unsigned int system_rev;
-#endif
+extern unsigned int hardware_type;
 
 static int taiko_hph_impedance_get(struct snd_kcontrol *kcontrol,
 				   struct snd_ctl_elem_value *ucontrol)
 {
-#if defined(CONFIG_MACH_KLTE_KOR)
-	if (system_rev >= 13) {
-		uint32_t zl, zr;
-		bool hphr;
-		struct soc_multi_mixer_control *mc;
-		struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
-		struct taiko_priv *priv = snd_soc_codec_get_drvdata(codec);
+	if (hardware_type == 1) {
+		if (system_rev >= 13) {
+			uint32_t zl, zr;
+			bool hphr;
+			struct soc_multi_mixer_control *mc;
+			struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
+			struct taiko_priv *priv = snd_soc_codec_get_drvdata(codec);
 
-		mc = (struct soc_multi_mixer_control *)(kcontrol->private_value);
+			mc = (struct soc_multi_mixer_control *)(kcontrol->private_value);
 
-		hphr = mc->shift;
-		wcd9xxx_mbhc_get_impedance(&priv->mbhc, &zl, &zr);
-		pr_debug("%s: zl %u, zr %u\n", __func__, zl, zr);
-		ucontrol->value.integer.value[0] = hphr ? zr : zl;
-	}
-#elif defined(CONFIG_MACH_KLTE_JPN)
-	if (system_rev >= 11) {
-		uint32_t zl, zr;
-		bool hphr;
-		struct soc_multi_mixer_control *mc;
-		struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
-		struct taiko_priv *priv = snd_soc_codec_get_drvdata(codec);
+			hphr = mc->shift;
+			wcd9xxx_mbhc_get_impedance(&priv->mbhc, &zl, &zr);
+			pr_debug("%s: zl %u, zr %u\n", __func__, zl, zr);
+			ucontrol->value.integer.value[0] = hphr ? zr : zl;
+		}
+	} else if (hardware_type == 2) {
+		if (system_rev >= 11) {
+			uint32_t zl, zr;
+			bool hphr;
+			struct soc_multi_mixer_control *mc;
+			struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
+			struct taiko_priv *priv = snd_soc_codec_get_drvdata(codec);
 
-		mc = (struct soc_multi_mixer_control *)(kcontrol->private_value);
+			mc = (struct soc_multi_mixer_control *)(kcontrol->private_value);
 
-		hphr = mc->shift;
-		wcd9xxx_mbhc_get_impedance(&priv->mbhc, &zl, &zr);
-		pr_debug("%s: zl %u, zr %u\n", __func__, zl, zr);
-		ucontrol->value.integer.value[0] = hphr ? zr : zl;
-	}
-#else
+			hphr = mc->shift;
+			wcd9xxx_mbhc_get_impedance(&priv->mbhc, &zl, &zr);
+			pr_debug("%s: zl %u, zr %u\n", __func__, zl, zr);
+			ucontrol->value.integer.value[0] = hphr ? zr : zl;
+		}
+	} else {
 #if !defined(CONFIG_SAMSUNG_JACK)
-	uint32_t zl, zr;
-	bool hphr;
-	struct soc_multi_mixer_control *mc;
-	struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
-	struct taiko_priv *priv = snd_soc_codec_get_drvdata(codec);
+		uint32_t zl, zr;
+		bool hphr;
+		struct soc_multi_mixer_control *mc;
+		struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
+		struct taiko_priv *priv = snd_soc_codec_get_drvdata(codec);
 
-	mc = (struct soc_multi_mixer_control *)(kcontrol->private_value);
+		mc = (struct soc_multi_mixer_control *)(kcontrol->private_value);
 
-	hphr = mc->shift;
-	wcd9xxx_mbhc_get_impedance(&priv->mbhc, &zl, &zr);
-	pr_debug("%s: zl %u, zr %u\n", __func__, zl, zr);
-	ucontrol->value.integer.value[0] = hphr ? zr : zl;
+		hphr = mc->shift;
+		wcd9xxx_mbhc_get_impedance(&priv->mbhc, &zl, &zr);
+		pr_debug("%s: zl %u, zr %u\n", __func__, zl, zr);
+		ucontrol->value.integer.value[0] = hphr ? zr : zl;
 #endif
-#endif
+	}
+
 	ucontrol->value.integer.value[0] = 0;
 	return 0;
 }
@@ -7242,43 +7242,43 @@ static int taiko_codec_probe(struct snd_soc_codec *codec)
 	else
 		rco_clk_rate = TAIKO_MCLK_CLK_9P6MHZ;
 
-#if defined(CONFIG_MACH_KLTE_KOR)
-	if (system_rev >= 13) {
-		/* init and start mbhc */
-		ret = wcd9xxx_mbhc_init(&taiko->mbhc, &taiko->resmgr, codec,
-					taiko_enable_mbhc_micbias,
-					&mbhc_cb, &cdc_intr_ids,
-					rco_clk_rate, false);
-		if (ret) {
-			pr_err("%s: mbhc init failed %d\n", __func__, ret);
-			goto err_init;
+	if (hardware_type == 1) {
+		if (system_rev >= 13) {
+			/* init and start mbhc */
+			ret = wcd9xxx_mbhc_init(&taiko->mbhc, &taiko->resmgr, codec,
+						taiko_enable_mbhc_micbias,
+						&mbhc_cb, &cdc_intr_ids,
+						rco_clk_rate, false);
+			if (ret) {
+				pr_err("%s: mbhc init failed %d\n", __func__, ret);
+				goto err_init;
+			}
 		}
-	}
-#elif defined(CONFIG_MACH_KLTE_JPN)
-	if (system_rev >= 11) {
-		/* init and start mbhc */
-		ret = wcd9xxx_mbhc_init(&taiko->mbhc, &taiko->resmgr, codec,
-					taiko_enable_mbhc_micbias,
-					&mbhc_cb, &cdc_intr_ids,
-					rco_clk_rate, false);
-		if (ret) {
-			pr_err("%s: mbhc init failed %d\n", __func__, ret);
-			goto err_init;
+	} else if (hardware_type == 2) {
+		if (system_rev >= 11) {
+			/* init and start mbhc */
+			ret = wcd9xxx_mbhc_init(&taiko->mbhc, &taiko->resmgr, codec,
+						taiko_enable_mbhc_micbias,
+						&mbhc_cb, &cdc_intr_ids,
+						rco_clk_rate, false);
+			if (ret) {
+				pr_err("%s: mbhc init failed %d\n", __func__, ret);
+				goto err_init;
+			}
 		}
-	}
-#else
+	} else {
 #if !defined(CONFIG_SAMSUNG_JACK)
-	/* init and start mbhc */
-	ret = wcd9xxx_mbhc_init(&taiko->mbhc, &taiko->resmgr, codec,
-				taiko_enable_mbhc_micbias,
-				&mbhc_cb, &cdc_intr_ids,
-				rco_clk_rate, false);
-	if (ret) {
-		pr_err("%s: mbhc init failed %d\n", __func__, ret);
-		goto err_init;
+		/* init and start mbhc */
+		ret = wcd9xxx_mbhc_init(&taiko->mbhc, &taiko->resmgr, codec,
+					taiko_enable_mbhc_micbias,
+					&mbhc_cb, &cdc_intr_ids,
+					rco_clk_rate, false);
+		if (ret) {
+			pr_err("%s: mbhc init failed %d\n", __func__, ret);
+			goto err_init;
+		}
+#endif
 	}
-#endif
-#endif
 
 	taiko->codec = codec;
 	for (i = 0; i < COMPANDER_MAX; i++) {
@@ -7424,22 +7424,23 @@ static int taiko_codec_remove(struct snd_soc_codec *codec)
 
 	taiko_cleanup_irqs(taiko);
 
-#if defined(CONFIG_MACH_KLTE_KOR)
-	if (system_rev >= 13) {
-		/* cleanup MBHC */
-		wcd9xxx_mbhc_deinit(&taiko->mbhc);
-	}
-#elif defined(CONFIG_MACH_KLTE_JPN)
-	if (system_rev >= 11) {
-		/* cleanup MBHC */
-		wcd9xxx_mbhc_deinit(&taiko->mbhc);
-	}
-#else
+	if (hardware_type == 1) {
+		if (system_rev >= 13) {
+			/* cleanup MBHC */
+			wcd9xxx_mbhc_deinit(&taiko->mbhc);
+		}
+	} else if (hardware_type == 2) {
+		if (system_rev >= 11) {
+			/* cleanup MBHC */
+			wcd9xxx_mbhc_deinit(&taiko->mbhc);
+		}
+	} else {
 #if !defined(CONFIG_SAMSUNG_JACK)
-	/* cleanup MBHC */
-	wcd9xxx_mbhc_deinit(&taiko->mbhc);
+		/* cleanup MBHC */
+		wcd9xxx_mbhc_deinit(&taiko->mbhc);
 #endif
-#endif
+	}
+
 	/* cleanup resmgr */
 	wcd9xxx_resmgr_deinit(&taiko->resmgr);
 

--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -236,9 +236,7 @@ static int main_mic_delay = 0;
 int speaker_status = 0;
 EXPORT_SYMBOL(speaker_status);
 #endif
-#if defined(CONFIG_MACH_KLTE_KOR) || defined(CONFIG_MACH_KLTE_JPN)
 static int fsa_en_gpio;
-#endif
 
 static int msm8974_liquid_ext_spk_power_amp_init(void)
 {
@@ -1708,9 +1706,8 @@ static int msm8974_taiko_event_cb(struct snd_soc_codec *codec,
 	}
 }
 
-#if defined(CONFIG_MACH_KLTE_KOR) || defined(CONFIG_MACH_KLTE_JPN)
 extern unsigned int system_rev;
-#endif
+extern unsigned int hardware_type;
 
 static int msm_audrx_init(struct snd_soc_pcm_runtime *rtd)
 {
@@ -1807,48 +1804,49 @@ static int msm_audrx_init(struct snd_soc_pcm_runtime *rtd)
 		}
 	}
 
-#if defined(CONFIG_MACH_KLTE_KOR)
-	if (system_rev >= 13) {
-		pr_info("%s: USE MBHC revision %d\n", __func__, system_rev);
-		/* start mbhc */
-		mbhc_cfg.calibration = def_taiko_mbhc_cal();
-		if (mbhc_cfg.calibration) {
-			err = taiko_hs_detect(codec, &mbhc_cfg);
-			if (err)
+	if (hardware_type == 1) {
+		if (system_rev >= 13) {
+			pr_info("%s: USE MBHC revision %d\n", __func__, system_rev);
+			/* start mbhc */
+			mbhc_cfg.calibration = def_taiko_mbhc_cal();
+			if (mbhc_cfg.calibration) {
+				err = taiko_hs_detect(codec, &mbhc_cfg);
+				if (err)
+					goto out;
+			} else {
+				err = -ENOMEM;
 				goto out;
-		} else {
-			err = -ENOMEM;
-			goto out;
+			}
 		}
-	}
-#elif defined(CONFIG_MACH_KLTE_JPN)
-	if (system_rev >= 11) {
-		pr_info("%s: USE MBHC revision %d\n", __func__, system_rev);
-		/* start mbhc */
-		mbhc_cfg.calibration = def_taiko_mbhc_cal();
-		if (mbhc_cfg.calibration) {
-			err = taiko_hs_detect(codec, &mbhc_cfg);
-			if (err)
+	} else if (hardware_type == 2) {
+		if (system_rev >= 11) {
+			pr_info("%s: USE MBHC revision %d\n", __func__, system_rev);
+			/* start mbhc */
+			mbhc_cfg.calibration = def_taiko_mbhc_cal();
+			if (mbhc_cfg.calibration) {
+				err = taiko_hs_detect(codec, &mbhc_cfg);
+				if (err)
+					goto out;
+			} else {
+				err = -ENOMEM;
 				goto out;
-		} else {
-			err = -ENOMEM;
-			goto out;
+			}
 		}
-	}
-#else
-#if !defined(CONFIG_SAMSUNG_JACK)
-	/* start mbhc */
-	mbhc_cfg.calibration = def_taiko_mbhc_cal();
-	if (mbhc_cfg.calibration) {
-		err = taiko_hs_detect(codec, &mbhc_cfg);
-		if (err)
-			goto out;
 	} else {
-		err = -ENOMEM;
-		goto out;
-	}
+#if !defined(CONFIG_SAMSUNG_JACK)
+		/* start mbhc */
+		mbhc_cfg.calibration = def_taiko_mbhc_cal();
+		if (mbhc_cfg.calibration) {
+			err = taiko_hs_detect(codec, &mbhc_cfg);
+			if (err)
+				goto out;
+		} else {
+			err = -ENOMEM;
+			goto out;
+		}
 #endif
-#endif /* CONFIG_MACH_KLTE_KOR */
+	}
+
 	adsp_state_notifier =
 	    subsys_notif_register_notifier("adsp",
 					   &adsp_state_notifier_block);
@@ -1856,19 +1854,20 @@ static int msm_audrx_init(struct snd_soc_pcm_runtime *rtd)
 		pr_err("%s: Failed to register adsp state notifier\n",
 		       __func__);
 		err = -EFAULT;
-#if defined(CONFIG_MACH_KLTE_KOR)
-		if (system_rev >= 13) {
-			taiko_hs_detect_exit(codec);
-		}
-#elif defined(CONFIG_MACH_KLTE_JPN)
-		if (system_rev >= 11) {
-			taiko_hs_detect_exit(codec);
-		}
-#else
+		if (hardware_type == 1) {
+			if (system_rev >= 13) {
+				taiko_hs_detect_exit(codec);
+			}
+		} else if (hardware_type == 2) {
+			if (system_rev >= 11) {
+				taiko_hs_detect_exit(codec);
+			}
+		} else {
 #if !defined(CONFIG_SAMSUNG_JACK)
-		taiko_hs_detect_exit(codec);
+			taiko_hs_detect_exit(codec);
 #endif
-#endif /* CONFIG_MACH_KLTE_KOR */
+		}
+
 		goto out;
 	}
 
@@ -3220,43 +3219,45 @@ static __devinit int msm8974_asoc_machine_probe(struct platform_device *pdev)
 		}
 	}
 
-#if defined(CONFIG_MACH_KLTE_KOR) || defined(CONFIG_MACH_KLTE_JPN)
-	/* enable FSA8039 for jack detection */
-	pr_info("%s: Check to enable FSA8039\n", __func__);
-	fsa_en_gpio = of_get_named_gpio(pdev->dev.of_node,
-					"qcom,earjack-fsa_en-gpio", 0);
-	if (fsa_en_gpio < 0)
-		of_property_read_u32(pdev->dev.of_node,
-			"qcom,earjack-fsa_en-expander-gpio", &fsa_en_gpio);
-	if (fsa_en_gpio < 0)
-		pr_info("%s: No support FSA8039 chip\n", __func__);
-	else
-		pr_info("%s: earjack-fsa_en-gpio =%d\n",
-						__func__, fsa_en_gpio);
+	if (hardware_type == 1 || hardware_type == 2) {
+		/* enable FSA8039 for jack detection */
+		pr_info("%s: Check to enable FSA8039\n", __func__);
+		fsa_en_gpio = of_get_named_gpio(pdev->dev.of_node,
+						"qcom,earjack-fsa_en-gpio", 0);
+		if (fsa_en_gpio < 0)
+			of_property_read_u32(pdev->dev.of_node,
+				"qcom,earjack-fsa_en-expander-gpio", &fsa_en_gpio);
+		if (fsa_en_gpio < 0)
+			pr_info("%s: No support FSA8039 chip\n", __func__);
+		else
+			pr_info("%s: earjack-fsa_en-gpio =%d\n",
+							__func__, fsa_en_gpio);
 
-	if (fsa_en_gpio > 0) {
-		ret = gpio_request(fsa_en_gpio, "fsa_en");
-		if (ret) {
-			pr_err("%s : gpio_request failed for %d, ret %d\n",
-				__func__, fsa_en_gpio, ret);
-			goto err;
+		if (fsa_en_gpio > 0) {
+			ret = gpio_request(fsa_en_gpio, "fsa_en");
+			if (ret) {
+				pr_err("%s : gpio_request failed for %d, ret %d\n",
+					__func__, fsa_en_gpio, ret);
+				goto err;
+			}
+			gpio_direction_output(fsa_en_gpio, 1);
 		}
-		gpio_direction_output(fsa_en_gpio, 1);
 	}
-#endif
+
 	/* the switch to connect the main mic to the codec or es705 */
-#if defined(CONFIG_MACH_KLTE_JPN)
+	if (hardware_type == 2) {
 #if defined(CONFIG_MACH_KLTE_MAX77828_JPN)
-	micbias_en_msm_gpio = of_get_named_gpio(pdev->dev.of_node,
-				"qcom,micbias-en-msm-gpio", 0);
+		micbias_en_msm_gpio = of_get_named_gpio(pdev->dev.of_node,
+					"qcom,micbias-en-msm-gpio", 0);
 #else
-	micbias_en_msm_gpio = of_get_named_gpio(pdev->dev.of_node,
-				"qcom,micbias-en-msm-jpn-gpio", 0);
+		micbias_en_msm_gpio = of_get_named_gpio(pdev->dev.of_node,
+					"qcom,micbias-en-msm-jpn-gpio", 0);
 #endif
-#else
-	micbias_en_msm_gpio = of_get_named_gpio(pdev->dev.of_node,
-				"qcom,micbias-en-msm-gpio", 0);
-#endif
+	} else {
+		micbias_en_msm_gpio = of_get_named_gpio(pdev->dev.of_node,
+					"qcom,micbias-en-msm-gpio", 0);
+	}
+
 	if (micbias_en_msm_gpio < 0) {
 		dev_err(&pdev->dev, "Looking up %s property in node %s failed",
 			"qcom,micbias-en-msm-gpio",


### PR DESCRIPTION
klteskt, kltektt, kltejpn uses a different jack configuration
compared to kltexx.

This commit adds a "samsung.hardware" boot command line recognizer to
match multiple variants' audio with single defconfig.

This commit has no effect if the user is not on SM-G900S/K/L/J or
"samsung.hardware" cmdline is not recognized.

Change-Id: I5ea8a93850b8415e01d7620703aaed6a09c420c4
Signed-off-by: arter97 qkrwngud825@gmail.com
